### PR TITLE
ЛР15-16. Исправление тестбенчей.

### DIFF
--- a/Labs/15. Programming device/tb_bluster.sv
+++ b/Labs/15. Programming device/tb_bluster.sv
@@ -65,6 +65,19 @@ module tb_blaster();
     instr_size = instr_mem_byte.size();
     data_size  = data_mem_byte.size();
     tiff_size  = tiff_mem_byte.size();
+    
+/*
+    RCV_NEXT_COMMAND
+*/
+    flash_addr = 32'h0000;
+    for(int i = MSG_ACK_SIZE-1; i >= 0; i--) begin
+      tx_data = flash_addr[i];
+      tx_valid = 1'b1;
+      @(posedge clk_i);
+      tx_valid = 1'b0;
+      @(posedge clk_i);
+      while(tx_busy) @(posedge clk_i);
+    end
 
 /*
     INIT_MSG
@@ -317,7 +330,7 @@ module tb_blaster();
       while(tx_busy) @(posedge clk_i);
     end
 
-    assert(!pc_reset_o)
+    assert(!core_reset_o)
     else $error("reset is not equal zero at the end");
 //  ----------------------------------------------
 
@@ -355,7 +368,7 @@ uart_tx tx(
 
   rw_instr_mem imem(
     .clk_i         (clk_i               ) ,
-    .addr_i        (instr_addr_i        ) ,
+    .read_addr_i   (instr_addr_i        ) ,
     .read_data_o   (instr_rdata_o       ) ,
     .write_addr_i  (instr_addr_o        ) ,
     .write_data_i  (instr_wdata_o       ) ,

--- a/Labs/16. Coremark/tb_coremark.sv
+++ b/Labs/16. Coremark/tb_coremark.sv
@@ -10,7 +10,7 @@ See https://github.com/MPSU/APS/blob/master/LICENSE file for licensing details.
 */
 module tb_coremark();
 
-  logic        clk10mhz_i;
+  logic        clk100mhz_i;
   logic        aresetn_i;
   logic        rx_i;
   logic        tx_o;
@@ -18,18 +18,19 @@ module tb_coremark();
   logic        rst_i;
 
   assign aresetn_i = !rst_i;
-  assign clk10mhz_i = clk_i;
 
   logic rx_busy, rx_valid, tx_busy, tx_valid;
   logic [7:0] rx_data, tx_data;
 
   always #50ns clk_i = !clk_i;
+  always #5ns clk100mhz_i = !clk100mhz_i;
 
   byte coremark_msg[103];
   integer coremark_cntr;
 
   initial begin
     $timeformat(-9, 2, " ns", 3);
+    clk100mhz_i = 0;
     clk_i = 0;
     rst_i <= 0;
     @(posedge clk_i);
@@ -58,7 +59,12 @@ module tb_coremark();
   end
 
   initial #500ms $finish();
-  riscv_top_asic DUT(.clk10mhz_i, .aresetn_i, .rx_i, .tx_o);
+  riscv_unit DUT(
+    .clk_i      (clk100mhz_i), 
+    .resetn_i   (aresetn_i), 
+    .rx_i       (rx_i), 
+    .tx_o       (tx_o)
+);
 
   uart_rx rx(
   .clk_i      (clk_i      ),

--- a/Labs/16. Coremark/tb_timer.sv
+++ b/Labs/16. Coremark/tb_timer.sv
@@ -21,9 +21,9 @@ module tb_timer();
   logic        interrupt_request_o;
 
 localparam SYS_CNT_ADDR = 32'h0000_0000;
-localparam DELAY_ADDR   = 32'h0000_0004;
-localparam MODE_ADDR    = 32'h0000_0008;
-localparam REP_CNT_ADDR = 32'h0000_000C;
+localparam DELAY_ADDR   = 32'h0000_0008;
+localparam MODE_ADDR    = 32'h0000_0010;
+localparam REP_CNT_ADDR = 32'h0000_0014;
 localparam RST_ADDR     = 32'h0000_0024;
 
 localparam OFF      = 32'd0;


### PR DESCRIPTION
В тестбенче [tb_bluster.sv](https://github.com/MPSU/APS/blob/master/Labs/15.%20Programming%20device/tb_bluster.sv): где он тестируется, как отдельный модуль
Пропущена обработка первого состояния (RCV_NEXT_COMMAND), в котором должна происходить подготовка к работе.
Два некорректных названий, расходятся с лабой.

В тестбенче [tb_top_asic.sv](https://github.com/MPSU/APS/blob/master/Labs/15.%20Programming%20device/tb_top_asic.sv): где программатор интегрируется в общую систему
Также нет обработки первого состояния и местами второго (RCV_NEXT_COMMAND и INIT_MSG).
Главная проблема была в тактовых сигналах. Их должно быть два: один 100 МГц, подающийся на основной модуль riscv_unit (там есть делитель частоты, который его превратит в 10 МГц) и 10 Мгц, который используется в самом тб.

В тестбенче [tb_timer.sv](https://github.com/MPSU/APS/blob/master/Labs/16.%20Coremark/tb_timer.sv): где проверяется отдельно таймер
После последнего изменения не совпадает адресное пространство.

В тестбенче [tb_coremark.sv](https://github.com/MPSU/APS/blob/master/Labs/16.%20Coremark/tb_coremark.sv):
Проблема с тактовыми сигналами. На модуль riscv_unit нужен 100 МГц, внутри тб 10 Мгц.