### PR TITLE
Имя порта совпадало с именем типа в peripheral_pkg.sv

### DIFF
--- a/Labs/13. Peripheral units/peripheral_pkg.sv
+++ b/Labs/13. Peripheral units/peripheral_pkg.sv
@@ -31,8 +31,8 @@ package peripheral_pkg;
     end
   endtask
 
-  task automatic uart_rx_send_char(input logic [7:0] char, input logic [31:0] baudrate, ref logic tx);
-    logic [11:0] data = {2'b11, (^char), char, 1'b0};
+  task automatic uart_rx_send_char(input logic [7:0] code, input logic [31:0] baudrate, ref logic tx);
+    logic [11:0] data = {2'b11, (^code), code, 1'b0};
     for(int i = 0; i < 12; i++) begin
       tx = data[i];
       #(1s/baudrate);

--- a/Labs/13. Peripheral units/peripheral_pkg.sv
+++ b/Labs/13. Peripheral units/peripheral_pkg.sv
@@ -31,8 +31,8 @@ package peripheral_pkg;
     end
   endtask
 
-  task automatic uart_rx_send_char(input logic [7:0] code, input logic [31:0] baudrate, ref logic tx);
-    logic [11:0] data = {2'b11, (^code), code, 1'b0};
+  task automatic uart_rx_send_char(input logic [7:0] character, input logic [31:0] baudrate, ref logic tx);
+    logic [11:0] data = {2'b11, (^character), character, 1'b0};
     for(int i = 0; i < 12; i++) begin
       tx = data[i];
       #(1s/baudrate);


### PR DESCRIPTION
Попытка посмотреть Elaborated Design приводит к ошибке в Vivado 2019.2, установленной на удалённом сервере

Сообщение об ошибке как бы намекает, что нельзя пропускать имя порта. Смена имени решила проблему

<details>
<summary>Содержимое Tcl Console</summary>

    synth_design -rtl -name rtl_1
    Command: synth_design -rtl -name rtl_1
    Starting synth_design
    Using part: xc7a100ticsg324-1L
    Top: processor_system
    ERROR: [Synth 8-1758] cannot omit port identifier for this declarations [/home/pin_34_19/Downloads/peripheral_pkg.sv:34]
    ERROR: [Synth 8-2715] syntax error near char [/home/pin_34_19/Downloads/peripheral_pkg.sv:34]
    ERROR: [Synth 8-2715] syntax error near char [/home/pin_34_19/Downloads/peripheral_pkg.sv:35]
    ERROR: [Synth 8-2715] syntax error near < [/home/pin_34_19/Downloads/peripheral_pkg.sv:36]
    INFO: [Synth 8-2350] module peripheral_pkg ignored due to previous errors [/home/pin_34_19/Downloads/peripheral_pkg.sv:42]
    Failed to read verilog '/home/pin_34_19/Downloads/peripheral_pkg.sv'
    1 Infos, 0 Warnings, 0 Critical Warnings and 5 Errors encountered.
    synth_design failed
    ERROR: [Vivado_Tcl 4-5] Elaboration failed - please see the console for details

тут уже опечатка в самом синтезаторе (*this* вместо *task*)
</details>