### PR TITLE
Добавление ссылки на репозиторий в конфигурацию mdBook

### DIFF
--- a/.github/book.toml
+++ b/.github/book.toml
@@ -4,3 +4,7 @@ language = "ru"
 multilingual = true
 src = "./"
 title = "Архитектуры процессорных систем"
+
+[output.html]
+git-repository-url = "https://github.com/MPSU/APS"
+git-repository-icon = "fa-github"


### PR DESCRIPTION
https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options
Добавляет в рендер mdBook вверху справа ссылку на репозиторий. Удобно для быстрого перехода из GitHub Pages в репозиторий.